### PR TITLE
updating the best seed on A10

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/README.md
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/README.md
@@ -207,8 +207,8 @@ Example output when running on Intel® PAC with Intel Arria® 10 GX FPGA for 327
 Device name: pac_a10 : Intel PAC Platform (pac_f000000)
 Generating 32768 random matrices
 Running QR decomposition of 32768 matrices repeatedly
-   Total duration:   42.3408 s
-Throughput: 24.7652k matrices/s
+   Total duration:   42.8803 s
+Throughput: 24.4536k matrices/s
 Verifying results on matrix 0 16384 32767
 PASSED
 ```

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/src/CMakeLists.txt
@@ -27,7 +27,7 @@ if(FPGA_BOARD MATCHES ".*a10.*")
     set(COLS_COMPONENT 128)
     set(FIXED_ITERATIONS 64)
     set(CLOCK_TARGET 360MHz)
-    set(SEED 31)
+    set(SEED 28)
 elseif(FPGA_BOARD MATCHES ".*s10.*")
     # S10 parameters
     set(ROWS_COMPONENT 256)


### PR DESCRIPTION
Signed-off-by: Yohann Uguen <yohann.uguen@intel.com>

# Existing Sample Changes
## Description

Setting the QRD seed to 28 to get maximum performance.

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran a large sweep of regression sweeps.
