### PR TITLE
FPGA: query USM support using the SYCL 2020 standard

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/anr/src/main.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/anr/src/main.cpp
@@ -92,7 +92,7 @@ int main(int argc, char* argv[]) {
 
   // make sure the device supports USM device allocations
   auto d = q.get_device();
-  if (!d.get_info<info::device::usm_device_allocations>()) {
+  if (!d.has(aspect::usm_device_allocations)) {
     std::cerr << "ERROR: The selected device does not support USM device"
               << " allocations\n";
     std::terminate();

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/gzip.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/gzip.cpp
@@ -217,7 +217,7 @@ int CompressFile(queue &q, std::string &input_file, std::vector<std::string> out
   // only supported on the PAC-S10-USM BSP. It's not
   // needed on PAC-A10 to achieve peak performance.
   bool isS10 =  (device_string.find("s10") != std::string::npos);
-  bool prepin = q.get_device().get_info<info::device::usm_host_allocations>();
+  bool prepin = q.get_device().has(aspect::usm_host_allocations);
 
   if (isS10 && !prepin) {
     std::cout << "Warning: Host allocations are not supported on this platform, which means that pre-pinning is not supported. DMA transfers may be slower than expected which may reduce application throughput.\n\n";

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/gzip_ll.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/gzip_ll.cpp
@@ -232,7 +232,7 @@ int CompressFile(queue &q, std::string &input_file,
   // only supported on the PAC-S10-USM BSP. It's not
   // needed on PAC-A10 to achieve peak performance.
   bool isS10 = (device_string.find("s10") != std::string::npos);
-  bool prepin = q.get_device().get_info<info::device::usm_host_allocations>();
+  bool prepin = q.get_device().has(aspect::usm_host_allocations);
 
   if (isS10 && !prepin) {
     std::cout << "Warning: Host allocations are not supported on this "

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/merge_sort/src/main.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/merge_sort/src/main.cpp
@@ -131,14 +131,14 @@ int main(int argc, char *argv[]) {
 
   // make sure the device supports USM device allocations
   auto d = q.get_device();
-  if (!d.get_info<info::device::usm_device_allocations>()) {
+  if (!q.get_device().has(aspect::usm_device_allocations)) {
     std::cerr << "ERROR: The selected device does not support USM device"
               << " allocations\n";
     std::terminate();
   }
 
   // make sure the device support USM host allocations if we chose to use them
-  if (!d.get_info<info::device::usm_host_allocations>() &&
+  if (!q.get_device().has(aspect::usm_host_allocations) &&
       kUseUSMHostAllocation) {
     std::cerr << "ERROR: The selected device does not support USM host"
               << " allocations\n";

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/FakeIOPipes.hpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/FakeIOPipes.hpp
@@ -65,12 +65,12 @@ class ProducerConsumerBaseImpl {
 
     // check for USM support
     device d = q.get_device();
-    if (!d.get_info<info::device::usm_host_allocations>() && use_host_alloc) {
+    if (!q.get_device().has(aspect::usm_host_allocations) && use_host_alloc) {
       std::cerr << "ERROR: The selected device does not support USM host"
                 << " allocations\n";
       std::terminate();
     }
-    if (!d.get_info<info::device::usm_device_allocations>()) {
+    if (!q.get_device().has(aspect::usm_device_allocations)) {
       std::cerr << "ERROR: The selected device does not support USM device"
                 << " allocations\n";
       std::terminate();


### PR DESCRIPTION
Signed-off-by: Yohann Uguen <yohann.uguen@intel.com>

# Existing Sample Changes
## Description

Using the SYCL 2020 syntax to query for USM host/device support.
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line